### PR TITLE
fix(exec): fix receiving multiple execs on same pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ shhh-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+/test/support/docker/known_hosts

--- a/lib/conn.ex
+++ b/lib/conn.ex
@@ -79,9 +79,6 @@ defmodule Shh.Conn do
 
       {:ssh_cm, ^ref, {message, ^id}} when message in [:eof, :closed] ->
         :closed
-
-      other ->
-        raise "TODO Need to handle other cases #{inspect(other)}"
     after
       timeout -> {:error, :timeout}
     end

--- a/lib/conn.ex
+++ b/lib/conn.ex
@@ -59,7 +59,7 @@ defmodule Shh.Conn do
 
       {:error, reason} ->
         # TODO raise a better exception
-        raise reason
+        raise Exception.normalize(:error, reason)
     end
   end
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -58,6 +58,127 @@ defmodule Shh.IntegrationTest do
     end
   end
 
+  describe "concurrent connections" do
+    @describetag user: :pubkey_user
+    setup [:one_host]
+
+    test "connections to same host can exec! concurrently without conflicts", %{
+      host: host
+    } do
+      # Create multiple connections to the same host
+      count = 10
+
+      expectations =
+        Enum.map(1..(count - 1), fn i ->
+          {
+            Shh.Conn.connect!(host.hostname,
+              port: host.port,
+              user: "pubkey_user",
+              user_dir: "./test/support/docker"
+            ),
+            "echo 'conn#{i}' && sleep 0.#{Enum.random(1..3)} && echo 'done#{i}'",
+            %Shh.Result{data: ["conn#{i}\n", "done#{i}\n"], exit_status: 0}
+          }
+        end) ++
+          [
+            {
+              Shh.Conn.connect!(host.hostname,
+                port: host.port,
+                user: "pubkey_user",
+                user_dir: "./test/support/docker"
+              ),
+              "cat /nonexistent/file",
+              %Shh.Result{
+                exit_status: 1,
+                errors: ["cat: can't open '/nonexistent/file': No such file or directory\n"]
+              }
+            }
+          ]
+
+      # Execute commands concurrently using async tasks
+      assert results =
+               expectations
+               |> Enum.map(fn {conn, command, _expect} ->
+                 Task.async(fn -> Shh.exec!(conn, command) end)
+               end)
+               |> Task.await_many(10_000)
+
+      assert length(results) == count
+
+      results
+      |> Enum.zip(expectations)
+      |> Enum.each(fn {result, {_conn, command, expected}} ->
+        assert match?(^expected, result), """
+          Shh connection ran: `#{command}`.
+
+          Expected:
+          #{inspect(expected)}
+
+          Recevied:
+          #{inspect(result)}
+        """
+      end)
+    end
+
+    test "connections to same host on the same pid can exec! without conflicts",
+         %{
+           host: host
+         } do
+      # Create multiple connections to the same host
+      count = 10
+
+      expectations =
+        Enum.map(1..(count - 1), fn i ->
+          {
+            Shh.Conn.connect!(host.hostname,
+              port: host.port,
+              user: "pubkey_user",
+              user_dir: "./test/support/docker"
+            ),
+            "echo 'conn#{i}' && sleep 0.#{Enum.random(1..3)} && echo 'done#{i}'",
+            %Shh.Result{data: ["conn#{i}\n", "done#{i}\n"], exit_status: 0}
+          }
+        end) ++
+          [
+            {
+              Shh.Conn.connect!(host.hostname,
+                port: host.port,
+                user: "pubkey_user",
+                user_dir: "./test/support/docker"
+              ),
+              "cat /nonexistent/file",
+              %Shh.Result{
+                exit_status: 1,
+                errors: ["cat: can't open '/nonexistent/file': No such file or directory\n"]
+              }
+            }
+          ]
+
+      # Execute commands concurrently using async tasks
+      assert results =
+               Enum.map(
+                 expectations,
+                 fn {conn, command, _expect} -> Shh.exec!(conn, command) end
+               )
+
+      assert length(results) == count
+
+      results
+      |> Enum.zip(expectations)
+      |> Enum.each(fn {result, {_conn, command, expected}} ->
+        assert match?(^expected, result), """
+          Shh connection ran: `#{command}`.
+
+          Expected:
+          #{inspect(expected)}
+
+          Recevied:
+          #{inspect(result)}
+        """
+      end)
+    end
+  end
+
   defp one_host(%{hosts: hosts}) do
     %{host: List.first(hosts)}
   end

--- a/test/shh_test.exs
+++ b/test/shh_test.exs
@@ -1,4 +1,27 @@
 defmodule ShhTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Shh
+
+  test "raises on exec! with closed connection" do
+    host = Shh.IntegrationCase.start_container!()
+
+    conn =
+      Shh.Conn.connect!(host.hostname,
+        port: host.port,
+        user: "pubkey_user",
+        user_dir: "./test/support/docker"
+      )
+
+    assert Shh.exec!(conn, "/app/mixed_output.sh") == %Shh.Result{
+             data: ["Normal: 1\nNormal: 2\n"],
+             errors: ["Error: 1\nError: 2\n"],
+             exit_status: 0
+           }
+
+    Docker.cmd!("stop", [host.id])
+
+    assert_raise ErlangError, "Erlang error: :closed", fn ->
+      Shh.exec!(conn, "/app/mixed_output.sh")
+    end
+  end
 end


### PR DESCRIPTION
When there are multiple `Shh.exec!(...)` happening quickly from the same pid, the `receive` loop can receive another exec's message, and currently explodes.

This adjusts to not have a catch-all so the message can wait in the queue and be received by the next receiver.


This also makes a closed connection's exception a little better. Currently, if a closed connection tries to exec, we'll get a `:closed.exception` exception when trying to render the error. Now at least it's an exception (aka, you cannot `raise :closed`)