### PR TITLE
fix: remove extra `:public_key` from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,6 @@ defmodule Shh.MixProject do
   def application do
     [
       extra_applications: [:logger, :public_key, :ssh],
-      included_applications: [:public_key, :ssh],
       mod: {Shh.Application, []}
     ]
   end


### PR DESCRIPTION
When including shh in a release `mix release`, mix errors with:

```
$ mix release
:public_key is listed both as a regular application and as an included application
```

The `:mod` is already specified for the supervision tree, and both `public_key` and `ssh` are listed as extra applications to startup, so I think `included_applications` is leftover from generating the project without `--sup` 